### PR TITLE
Add support for preAssignBindingsEnabled on ES6 classes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log
 .vscode
 *.log
 *.stackdump
+dist/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,6 +133,11 @@ module.exports = function(grunt) {
         dest: 'build/angular-parse-ext.js',
         src: util.wrap(files['angularModules']['ngParseExt'], 'module')
       },
+      ngComponent: {
+        dest: 'build/ngComponent.js',
+        src: files['angularModules']['ngComponent'],
+        strict: false
+      },
       'promises-aplus-adapter': {
         dest:'tmp/promises-aplus-adapter++.js',
         src:['src/ng/q.js', 'lib/promises-aplus/promises-aplus-test-adapter.js']

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -2,6 +2,7 @@
 
 var angularFiles = {
   'angularSrc': [
+    'src/es6Bindings/compilationBindings.js',
     'src/minErr.js',
     'src/Angular.js',
     'src/loader.js',
@@ -151,6 +152,9 @@ var angularFiles = {
     ],
     'ngAria': [
       'src/ngAria/aria.js'
+    ],
+    'ngComponent': [
+      'src/es6Bindings/ngComponent.js'
     ]
   },
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "grunt": "^1.2.0"
   },
   "scripts": {
-    "build": "grunt package"
+    "build": "grunt package",
+    "package:angular": "node ./scripts/packaging/packageAngular.js"
   },
   "devDependencies": {
     "angular-benchpress": "0.x.x",

--- a/scripts/packaging/packageAngular.js
+++ b/scripts/packaging/packageAngular.js
@@ -1,0 +1,54 @@
+/* eslint-disable */
+const fs = require("fs");
+const path = require("path");
+const process = require("process");
+
+const basePath = process.cwd();
+const packageDir = path.join(basePath, "./dist/angular");
+const buildDir = path.join(basePath, "./build");
+const version = require("../../build/version.json");
+
+const filesToCopy = [
+  "angular.js",
+  "angular.min.js",
+  "angular.min.js.map",
+  "angular-csp.css",
+  "ngComponent.js"
+];
+
+const indexJs = `require("./angular");\nmodule.exports = angular;`;
+
+const packageJson = {
+  name: "angular",
+  version: version.full,
+  description: "HTML enhanced for web apps",
+  main: "index.js",
+  scripts: {
+    test: "echo \"Error: no test specified\" && exit 1"
+  },
+  repository: {
+    type: "git",
+    url: "https://github.com/angular/angular.js.git"
+  },
+  keywords: [
+    "angular",
+    "framework",
+    "browser",
+    "client-side"
+  ],
+  author: "Angular Core Team <angular-core+npm@google.com>",
+  license: "MIT",
+  bugs: {
+    url: "https://github.com/angular/angular.js/issues"
+  },
+  homepage: "https://angularjs.org"
+};
+
+fs.rmSync(packageDir, { recursive: true, force: true });
+
+fs.mkdirSync(packageDir, { recursive: true });
+filesToCopy.forEach((f) => fs.copyFileSync(path.join(buildDir, f), path.join(packageDir, f)));
+
+fs.writeFileSync(path.join(packageDir, "index.js"), indexJs);
+fs.writeFileSync(path.join(packageDir, "package.json"), JSON.stringify(packageJson, null, 4));
+fs.copyFileSync(path.join(basePath, "LICENSE"), path.join(packageDir, "LICENSE.md"));

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -102,6 +102,7 @@
     "VALIDITY_STATE_PROPERTY": false,
     "reloadWithDebugInfo": false,
     "stringify": false,
+    "compilationBindings": false,
 
     "NODE_TYPE_ELEMENT": false,
     "NODE_TYPE_ATTRIBUTE": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -95,6 +95,7 @@
   hasOwnProperty,
   createMap,
   stringify,
+  compilationBindings
 
   NODE_TYPE_ELEMENT,
   NODE_TYPE_ATTRIBUTE,

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -159,7 +159,8 @@ function publishExternalAPI(angular) {
     '$$csp': csp,
     '$$encodeUriSegment': encodeUriSegment,
     '$$encodeUriQuery': encodeUriQuery,
-    '$$stringify': stringify
+    '$$stringify': stringify,
+    '$$compilationBindings': compilationBindings
   });
 
   angularModule = setupModuleLoader(window);

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -946,7 +946,12 @@ function createInjector(modulesToLoad, strictDi) {
         return fn.apply(self, args);
       } else {
         args.unshift(null);
-        return new (Function.prototype.bind.apply(fn, args))();
+        compilationBindings.current = self;
+
+        var instance = new (Function.prototype.bind.apply(fn, args))();
+        compilationBindings.current = null;
+
+        return instance;
       }
     }
 

--- a/src/es6Bindings/compilationBindings.js
+++ b/src/es6Bindings/compilationBindings.js
@@ -1,0 +1,4 @@
+'use strict';
+var compilationBindings = {
+  current: null
+};

--- a/src/es6Bindings/ngComponent.js
+++ b/src/es6Bindings/ngComponent.js
@@ -1,0 +1,8 @@
+'use strict';
+export class NgComponent {
+  constructor() {
+    if (window.angular.$$compilationBindings.current !== null) {
+      Object.assign(this, window.angular.$$compilationBindings.current);
+    }
+  }
+}


### PR DESCRIPTION
Add support for `preAssignBindingsEnabled` on ES6 classes. 
Add script to package Angular.js ready for isolated publishing.

Consumers can get ES6 classes working with `preAssignBindingsEnabled` via extending the newly exported `NgComponent`

Example usage
```javascript
import { NgComponent } from "angular/ngComponent";

class Test extends NgComponent {
    constructor($element) {
        super();
        console.log(this, $element);
    }

    doStuff() {
        return "Soon™";
    }
}
Test.$inject = ["$element"];

const testDefinition = {
    bindings: {
        a: "<",
        b: "<",
        c: "<"
    },
    template: `<div>{{$ctrl.a}} | {{$ctrl.b}} | {{$ctrl.c}} | {{::$ctrl.doStuff()}}</div>`,
    controller: Test
};

myModule.component("test", testDefinition);
```