### PR TITLE
2.0.1 Fix improper sanitisation of href and xlink:href on SVG image elements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="2.0.1"></a>
+# 2.0.1
+
+## Bug Fixes
+- Fixed CVE-2025-0716 vulnerability
+
+
 <a name="2.0.0"></a>
 # 2.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angularjs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angularjs",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@swc/core": "^1.7.26",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "angularjs",
   "license": "MIT",
-  "version": "2.0.0",
-  "distTag": "2.0.0",
+  "version": "2.0.1",
+  "distTag": "2.0.1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1772,7 +1772,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
           nodeName = nodeName_(this.$$element);
 
-          if ((nodeName === 'a' && (key === 'href' || key === 'xlinkHref')) || ((nodeName === 'img' || nodeName === 'source') && key === 'src')) {
+          if (
+            ((nodeName === 'a' || nodeName === 'image') && (key === 'href' || key === 'xlinkHref')) ||
+            ((nodeName === 'img' || nodeName === 'source') && key === 'src')
+          ) {
             // sanitize a[href] and img[src] values
             this[key] = value = (value == null) ? value : $$sanitizeUri(value, key === 'src');
           } else if ((nodeName === 'img' || nodeName === 'source') && key === 'srcset' && isDefined(value)) {
@@ -3328,7 +3331,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         } else if (attrNormalizedName === 'xlinkHref' ||
             (tag === 'form' && attrNormalizedName === 'action') ||
             // links can be stylesheets or imports, which can run script in the current origin
-            (tag === 'link' && attrNormalizedName === 'href')
+            (tag === 'link' && attrNormalizedName === 'href') ||
+            // SVG image href can be abused (content spoofing)
+            (tag === "image" && attrNormalizedName === 'href')
         ) {
           return $sce.RESOURCE_URL;
         }


### PR DESCRIPTION
Fix improper sanitisation of href and xlink:href on SVG image elements 

- https://security.snyk.io/vuln/SNYK-JS-ANGULAR-9919773
- https://www.cve.org/CVERecord?id=CVE-2025-0716

Demo showing off unsafe behaviour: https://codepen.io/herodevs/pen/qEWQmpd/a86a0d29310e12c7a3756768e6c7b915

<details>
<summary>Test file to show it off working:</summary>

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>CVE-2025-0716</title>
  <style>
    /* Styles */
    aside {
      border: 0.1rem solid lightgray;
      border-radius: 0.5rem;
      font-size: 0.9rem;
      margin: 0.5rem;
      padding: 0.5rem;
    }
    aside.info {
      background-color: aliceblue;
    }
    aside.warn {
      background-color: lemonchiffon;
    }

    body {
      font-family: sans-serif;
      font-size: 1rem;
    }

    code {
      font-size: 1.1em;
    }
    code::before,
    code::after {
      content: '`';
    }

    h1 {
      text-align: center;
    }
    h1 > small {
      display: inline-block;
      font-style: italic;
      padding-block-end: 0.5rem;
    }

    pre {
      background-color: lightgray;
      border: 1px solid dimgray;
      border-radius: 0.25rem;
      overflow: auto;
      padding: 0.5rem;
      white-space: pre-line;
    }

    section {
      border-block-start: 2px solid gray;
      padding: 0 1rem 1rem;
    }

    .vulnerability-info-table {
      border-spacing: 0.5rem;
      margin-inline-end: 1rem;
    }
    .vulnerability-info-table th {
      text-align: start;
      vertical-align: top;
      white-space: nowrap;
    }

    .repro-content-section button {
      margin: 0.25rem;
    }

    .repro-content-section .repro-btn {
      position: relative;
    }
    .repro-content-section .repro-btn::after {
      animation: spinner 0.5s linear infinite;
      border-radius: 50%;
      border-right: 2px solid transparent;
      border-top: 2px solid darkorchid;
      content: '';
      display: none;
      height: 1rem;
      margin-top: -0.5rem;
      position: absolute;
      right: -2rem;
      top: 50%;
      width: 1rem;
    }
    .repro-content-section .repro-btn:active::after {
      display: initial;
    }
    .repro-content-section .repro-btn:active + .repro-duration {
      visibility: hidden;
    }

    .repro-content-section .repro-duration {
      border-inline-start: 2px solid gray;
      padding-inline-start: 0.33rem;
    }

    .repro-content-section .repro-images {
      display: grid;
      gap: 1rem;
      grid-template-columns: auto 100px;
      grid-auto-rows: 1fr;
      justify-content: start;
      place-items: center stretch;
    }
    .repro-content-section .repro-images svg {
      justify-self: center;
      max-height: 50px;
      max-width: 50px;
    }
    .repro-content-section .repro-images svg image {
      width: 50px;
    },
    .repro-content-section .repro-images svg image[href^="unsafe:"]:after,
    .repro-content-section .repro-images svg image[xlink\:href^="unsafe:"]:after {
      content: '🚫 BLOCKED';
      white-space: pre;
    }
    .repro-content-section .repro-images .section-header {
      border-top: 1px solid;
      font-weight: bold;
      grid-column: 1 / -1;
      padding-top: 1rem;
      text-align: center;
      text-decoration: underline;
    }

    .repro-instructions-section li {
      margin-block-end: 0.5rem;
    }

    /* Animation keyframes */
    @keyframes spinner {
      to {
        transform: rotate(360deg);
      }
    }
  </style>
  <script src="./dist/@pebblepad/angular/angular.js"></script>
</head>
<body>
<h1>
  <small>Reproduction of AngularJS vulnerability:</small><br />
  <code>(ng(Attr))Href</code> SVG image source sanitization bypass
</h1>

<section class="vulnerability-info-section">
  <h2>Vulnerability information</h2>
  <table class="vulnerability-info-table">
    <tr>
      <th>CVE:</th>
      <td><a href="https://www.cve.org/CVERecord?id=CVE-2025-0716">CVE-2025-0716</a></td>
    </tr>
    <tr>
      <th>Type:</th>
      <td>Image source sanitization bypass (a form of <a href="https://owasp.org/www-community/attacks/Content_Spoofing">Content Spoofing</a>)</td>
    </tr>
    <tr>
      <th>Affected versions:</th>
      <td>&gt;=0.0.0</td>
    </tr>
    <tr>
      <th>Fixed in version:</th>
      <td><a href="https://www.herodevs.com/support/nes-angularjs">AngularJS NES</a> v1.9.8 and v1.5.24</td>
    </tr>
    <tr>
      <th>Description:</th>
      <td>
        Setting an <code>&lt;image></code> SVG element's <code>href</code> attribute value via the <a href="https://docs.angularjs.org/api/ng/directive/ngHref">ngHref</a> and <a href="https://docs.angularjs.org/guide/interpolation#-ngattr-for-binding-to-arbitrary-attributes">ngAttrHref</a> directives or using <a href="https://docs.angularjs.org/guide/interpolation">interpolation</a> is not subject to <a href="https://docs.angularjs.org/api/ng/provider/$compileProvider#imgSrcSanitizationTrustedUrlList">image source sanitization</a>. As a result, no restrictions are applied to the images that can be shown, which can also lead to a form of <a href="https://owasp.org/www-community/attacks/Content_Spoofing">Content Spoofing</a>. Similarly, the app's performance and behavior can be negatively affected by using too large or slow-to-load images.

        <aside class="info">
          <b>NOTE</b><br />
          Targeting the <code>xlink:href</code> attribute via <code>ng-attr-xlink:href</code> or interpolation is not affected. With <code>xlink:href</code>, sanitization works as intended.
        </aside>
      </td>
    </tr>
  </table>
</section>

<section class="repro-instructions-section">
  <h2>Reproduction instructions</h2>
  <p>
    The app below demonstrates the issue by trying to load images that should be blocked by the image source sanitization rules. It is doing so by binding to an <code>&lt;image></code> SVG element's <code>href</code> attribute using <code>ngHref</code>, <code>ngAttrHref</code> and <code>href</code> interpolation.
  </p>
  <p>
    For demonstration purposes, the app is configured to only allow images from the <code>https://angularjs.org/</code> domain:
  <pre>
      $compileProvider.imgSrcSanitizationTrustedUrlList(/^https:\/\/angularjs\.org\//);
    </pre>
  </p>
  <p>
    However, by taking advantage of the lack of sanitization in <code>ngHref</code>, <code>ngAttrHref</code> and <code>href</code> interpolation, we are able to show images from other domains (e.g. <code>https://angular.dev/</code>) as well as different schemes (e.g. an arbitrary SVG image using the <code>data:image/svg+xml</code> format).
  </p>
  <p>
    <b>Steps:</b>
  <ol>
    <li>
      Take a look at the table below.
    </li>
    <li>
      For reference, the first 6 entries use non-vulnerable methods, such as targeting the <code>xlink:href</code> attribute or using the <code>ngHref</code> directive with hard-codes values (i.e. no interpolation), and demonstrate that the image sources are sanitized correctly, not allowing images outside <code>https://angularjs.org/</code> to show.
    </li>
    <li>
      In contrast, the last 6 entries use vulnerable methods to target the <code>href</code> attribute, thus bypassing sanitization and allowing us to show images that should be blocked.
    </li>
  </ol>
  </p>
</section>

<section class="repro-content-section" ng-app="app">
  <h2>Reproduction</h2>
  <p class="repro-images">
    <span class="section-header">
      Examples with <code>xlink:href</code> + interpolation<br />
      (not vulnerable)
    </span>

    <span>
      Image from <code>angular.dev</code>:<br />
      <b>BLOCKED</b> (Correct ✔️)
    </span>
    <svg>
      <image xlink:href="{{ 'https://angular.dev/favicon.ico' }}"></image>
    </svg>

    <span>
      Arbitrary SVG image via data URL:<br />
      <b>BLOCKED</b> (Correct ✔️)
    </span>
    <svg>
      <image xlink:href="{{ 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48dGV4dCBmb250LXNpemU9IjEwMCIgeT0iMWVtIj7wn5Cx4oCN8J+SuzwvdGV4dD48L3N2Zz4=' }}"></image>
    </svg>


    <!-- -------------------------------------------------- -->

    <span class="section-header">
      Examples with <code>ng-href</code> (without interpolation)<br />
      (not vulnerable)
    </span>

    <span>
      Image from <code>angular.dev</code>:<br />
      <b>BLOCKED</b> (Correct ✔️)
    </span>
    <svg>
      <image ng-href="https://angular.dev/favicon.ico" xlink:href=""></image>
    </svg>

    <span>
      Arbitrary SVG image via data URL:<br />
      <b>BLOCKED</b> (Correct ✔️)
    </span>
    <svg>
      <image ng-href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48dGV4dCBmb250LXNpemU9IjEwMCIgeT0iMWVtIj7wn5Cx4oCN8J+SuzwvdGV4dD48L3N2Zz4=" xlink:href=""></image>
    </svg>

    <!-- -------------------------------------------------- -->

    <span class="section-header">
      Examples with <code>ng-attr-xlink:href</code><br />
      (not vulnerable)
    </span>

    <span>
      Image from <code>angular.dev</code>:<br />
      <b>BLOCKED</b> (Correct ✔️)
    </span>
    <svg>
      <image ng-attr-xlink:href="https://angular.dev/favicon.ico" xlink:href=""></image>
    </svg>

    <span>
      Arbitrary SVG image via data URL:<br />
      <b>BLOCKED</b> (Correct ✔️)
    </span>
    <svg>
      <image ng-attr-xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48dGV4dCBmb250LXNpemU9IjEwMCIgeT0iMWVtIj7wn5Cx4oCN8J+SuzwvdGV4dD48L3N2Zz4=" xlink:href=""></image>
    </svg>


    <span class="section-header">
      Extra checks to ensure expected scenarios continue to work
    </span>
    <span>xlink:href</span>
    <svg>
      <image xlink:href="https://angularjs.org/img/angularjs-for-header-only.svg"></image>
    </svg>

    <span>href</span>
    <svg>
      <image href="https://angularjs.org/img/angularjs-for-header-only.svg" xlink:href=""></image>
    </svg>

    <span>ng-href</span>
    <svg>
      <image ng-href="https://angularjs.org/img/angularjs-for-header-only.svg" xlink:href=""></image>
    </svg>

    <span>ng-attr-xlink</span>
    <svg>
      <image ng-attr-xlink:href="https://angularjs.org/img/angularjs-for-header-only.svg" xlink:href=""></image>
    </svg>

    <span>ng-attr-href</span>
    <svg>
      <image ng-attr-href="https://angularjs.org/img/angularjs-for-header-only.svg"></image>
    </svg>

    <span>Interpolation</span>
    <svg>
      <image href="{{ 'https://angularjs.org/img/angularjs-for-header-only.svg' }}"></image>
    </svg>

    <span>ng-href interpolation</span>
    <svg>
      <image ng-href="{{ 'https://angularjs.org/img/angularjs-for-header-only.svg' }}" xlink:href=""></image>
    </svg>
    <!-- -------------------------------------------------- -->

    <span class="section-header">
      Examples with <code>href</code> + interpolation<br />
      (vulnerable)
    </span>

    <span>
      Image from <code>angular.dev</code>:<br />
      <b>ALLOWED</b> (Error ❌)
    </span>
    <svg>
      <image href="{{ 'https://angular.dev/favicon.ico' }}"></image>
    </svg>

    <span>
      Arbitrary SVG image via data URL:<br />
      <b>ALLOWED</b> (Error ❌)
    </span>
    <svg>
      <image href="{{ 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48dGV4dCBmb250LXNpemU9IjEwMCIgeT0iMWVtIj7wn5Cx4oCN8J+SuzwvdGV4dD48L3N2Zz4=' }}"></image>
    </svg>

    <!-- -------------------------------------------------- -->

    <span class="section-header">
      Examples with <code>ng-href</code> + interpolation<br />
      (vulnerable)
    </span>

    <span>
      Image from <code>angular.dev</code>:<br />
      <b>ALLOWED</b> (Error ❌)
    </span>
    <svg>
      <image ng-href="{{ 'https://angular.dev/favicon.ico' }}" xlink:href=""></image>
    </svg>

    <span>
      Arbitrary SVG image via data URL:<br />
      <b>ALLOWED</b> (Error ❌)
    </span>
    <svg>
      <image ng-href="{{ 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48dGV4dCBmb250LXNpemU9IjEwMCIgeT0iMWVtIj7wn5Cx4oCN8J+SuzwvdGV4dD48L3N2Zz4=' }}" xlink:href=""></image>
    </svg>
    BOB
    <svg>
      <image ng-href="{{ 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48dGV4dCBmb250LXNpemU9IjEwMCIgeT0iMWVtIj7wn5Cx4oCN8J+SuzwvdGV4dD48L3N2Zz4=' }}"></image>
    </svg>
    <!-- -------------------------------------------------- -->

    <span class="section-header">
      Examples with <code>ng-attr-href</code><br />
      (vulnerable)
    </span>

    <span>
      Image from <code>angular.dev</code>:<br />
      <b>ALLOWED</b> (Error ❌)
    </span>
    <svg>
      <image ng-attr-href="https://angular.dev/favicon.ico"></image>
    </svg>

    <span>
      Arbitrary SVG image via data URL:<br />
      <b>ALLOWED</b> (Error ❌)
    </span>
    <svg>
      <image ng-attr-href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48dGV4dCBmb250LXNpemU9IjEwMCIgeT0iMWVtIj7wn5Cx4oCN8J+SuzwvdGV4dD48L3N2Zz4="></image>
    </svg>
  </p>
</section>
<script>
  // Define and configure the app.
  angular
    .module('app', [])
    .config(['$compileProvider', '$sceDelegateProvider', ($compileProvider, $sceDelegateProvider) => {
      $compileProvider.imgSrcSanitizationWhitelist(/^https:\/\/angularjs\.org\//);
      $compileProvider.aHrefSanitizationWhitelist(/^https:\/\/angularjs\.org\//);
      $sceDelegateProvider.resourceUrlWhitelist([
        "self",
        "https://angularjs.org/**"
      ])
    }]);

</script>
</body>
</html>
```

</details>