### PR TITLE
2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="2.1.0"></a>
+# 2.1.0
+
+## New Features
+- Added `createWith` method on `$injector`. Allows consumers to manually create instances or get results of factories with dependency arguments, bypassing traditional lookup.
+
+
 <a name="2.0.1"></a>
 # 2.0.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angularjs",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angularjs",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@swc/core": "^1.7.26",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "angularjs",
   "license": "MIT",
-  "version": "2.0.1",
-  "distTag": "2.0.1",
+  "version": "2.1.0",
+  "distTag": "2.1.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -945,19 +945,23 @@ function createInjector(modulesToLoad, strictDi) {
         fn = fn[fn.length - 1];
       }
 
-      if (!isClass(fn)) {
+      return createWith(fn, self, args);
+    }
+
+    function createWith(functionOrClass, context, args) {
+      if (!isClass(functionOrClass)) {
         // http://jsperf.com/angularjs-invoke-apply-vs-switch
         // #5388
-        return fn.apply(self, args);
-      } else {
-        args.unshift(null);
-        compilationBindings.current = self;
-
-        var instance = new (Function.prototype.bind.apply(fn, args))();
-        compilationBindings.current = null;
-
-        return instance;
+        return functionOrClass.apply(context, args);
       }
+
+      args.unshift(null);
+      compilationBindings.current = context;
+
+      var instance = new (Function.prototype.bind.apply(functionOrClass, args))();
+      compilationBindings.current = null;
+
+      return instance;
     }
 
 
@@ -973,6 +977,7 @@ function createInjector(modulesToLoad, strictDi) {
 
 
     return {
+      createWith: createWith,
       invoke: invoke,
       instantiate: instantiate,
       get: getService,

--- a/workspace-scripts/config/Version.js
+++ b/workspace-scripts/config/Version.js
@@ -1,1 +1,1 @@
-export const version = "2.0.1";
+export const version = "2.1.0";


### PR DESCRIPTION
Add `createWith` method on `$injector`. 
Allows consumers to manually create instances or get results of factories with dependency arguments, bypassing traditional lookup.

Especially useful for hybrid custom Dependency Injection systems working between frameworks.