### PR TITLE
2.1.1 Fix improper sanitisation of href and xlink:href on SVG image elements when using $sanitize (e.g. ng-bind-html)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="2.1.1"></a>
+# 2.1.1
+
+## Bug Fixes
+-  Fix CVE-2025-2336 vulnerability
+
+
 <a name="2.1.0"></a>
 # 2.1.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angularjs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angularjs",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "@swc/core": "^1.7.26",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "angularjs",
   "license": "MIT",
-  "version": "2.1.0",
-  "distTag": "2.1.0",
+  "version": "2.1.1",
+  "distTag": "2.1.1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -612,7 +612,7 @@ function $SanitizeProvider() {
           out(tag);
           forEach(attrs, function(value, key) {
             var lkey = lowercase(key);
-            var isImage = (tag === 'img' && lkey === 'src') || (lkey === 'background');
+            var isImage = (tag === 'img' && lkey === 'src') || (lkey === 'background') || (tag === 'image' && (lkey === 'href' || lkey ==='xlink:href'));
             if (validAttrs[lkey] === true &&
               (uriAttrs[lkey] !== true || uriValidator(value, isImage))) {
               out(' ');

--- a/workspace-scripts/config/Version.js
+++ b/workspace-scripts/config/Version.js
@@ -1,1 +1,1 @@
-export const version = "2.1.0";
+export const version = "2.1.1";


### PR DESCRIPTION
Fix improper sanitisation of href and xlink:href on SVG image elements

https://www.cve.org/CVERecord?id=CVE-2025-2336
https://www.herodevs.com/vulnerability-directory/cve-2025-0716?angularjs-nes

Demo showing off unsafe behaviour: https://codepen.io/herodevs/pen/bNGYaXx/412a3a4218387479898912f60c269c6c

<details>
<summary>Test file to show it off working:</summary>

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>CVE-2025-2336</title>
  <script src="./dist/angular/angular.js"></script>
  <script src="./dist/angular-sanitize/angular-sanitize.js"></script>
  <style>
    /* Styles */
    aside {
      border: 0.1rem solid lightgray;
      border-radius: 0.5rem;
      font-size: 0.95em;
      margin: 0.5rem;
      padding: 0.5rem;
    }

    aside.info {
      background-color: aliceblue;
    }

    aside.warn {
      background-color: lemonchiffon;
    }

    body {
      font-family: arial, sans-serif;
      font-size: 1rem;
    }

    code {
      background-color: rgba(0, 0, 0, 0.125);
      border: 1px dotted darkgray;
      border-radius: 3px;
      display: inline-block;
      font-size: 0.95em;
      padding-left: 0.25rem;
      padding-right: 0.25rem;
    }

    h1 {
      text-align: center;
    }

    h1 > small {
      display: inline-block;
      font-style: italic;
      padding-block-end: 0.5rem;
    }

    pre {
      background-color: lightgray;
      border: 1px solid dimgray;
      border-radius: 0.25rem;
      font-size: 0.95em;
      overflow: auto;
      padding: 0.5rem;
      white-space: pre-line;
    }

    section {
      border-block-start: 2px solid gray;
      padding: 0 1rem 1rem;
    }

    .vulnerability-info-table {
      border-spacing: 0.5rem;
      margin-inline-end: 1rem;
    }

    .vulnerability-info-table th {
      text-align: start;
      vertical-align: top;
      white-space: nowrap;
    }

    .repro-content-section {
      position: relative;
    }

    .repro-content-section button {
      margin: 0.25rem;
    }

    .repro-content-section label > span {
      display: inline-block;
      min-width: 13rem;
    }

    .repro-content-section .repro-btn {
      position: relative;
    }

    .repro-content-section .repro-btn::after {
      animation: spinner 0.5s linear infinite;
      border-radius: 50%;
      border-right: 2px solid transparent;
      border-top: 2px solid darkorchid;
      content: '';
      display: none;
      height: 1rem;
      margin-top: -0.5rem;
      position: absolute;
      right: -2rem;
      top: 50%;
      width: 1rem;
    }

    .repro-content-section .repro-btn:active::after {
      display: initial;
    }

    .repro-content-section .repro-btn:active + .repro-duration {
      visibility: hidden;
    }

    .repro-content-section .repro-duration {
      border-inline-start: 2px solid gray;
      padding-inline-start: 0.33rem;
    }

    .repro-content-section .rendered-html img,
    .repro-content-section .rendered-html svg {
      height: 60px;
      width: 60px;
    }

    .repro-content-section .rendered-html svg image {
      height: 100%;
      width: 100%;
    }

    .repro-content-section .version-stamp {
      font-size: 0.67em;
      font-style: italic;
      position: absolute;
      right: 0;
      top: 1.67rem;
    }

    .repro-instructions-section li {
      margin-block-end: 0.5rem;
    }

    /* Animation keyframes */
    @keyframes spinner {
      to {
        transform: rotate(360deg);
      }
    }
  </style>
</head>
<body>
<h1>
  <small>Reproduction of AngularJS vulnerability:</small><br/>
  <code>ngSanitize</code> SVG image source sanitization bypass
</h1>

<section class="vulnerability-info-section">
  <h2>Vulnerability information</h2>
  <table class="vulnerability-info-table">
    <tr>
      <th>CVE:</th>
      <td><a href="https://www.cve.org/CVERecord?id=CVE-2025-2336">CVE-2025-2336</a></td>
    </tr>
    <tr>
      <th>Type:</th>
      <td>Image source sanitization bypass (a form of <a
        href="https://owasp.org/www-community/attacks/Content_Spoofing">Content Spoofing</a>)
      </td>
    </tr>
    <tr>
      <th>Affected versions:</th>
      <td>&gt;=1.3.1</td>
    </tr>
    <tr>
      <th>Fixed in version:</th>
      <td><a href="https://www.herodevs.com/support/nes-angularjs">AngularJS NES</a> v1.9.9 and v1.5.25</td>
    </tr>
    <tr>
      <th>Description:</th>
      <td>
        The <a href="https://docs.angularjs.org/api/ngSanitize/service/$sanitize">$sanitize</a> service is used for
        sanitizing HTML strings by stripping all potentially dangerous tokens. As part of the sanitization, it checks
        the URLs of images to ensure they abide by the defined <a
        href="https://docs.angularjs.org/api/ng/provider/$compileProvider#imgSrcSanitizationTrustedUrlList">image source
        rules</a>. However, SVG <code>&lt;image></code> elements are not correctly detected as images by the <code>$sanitize</code>
        service. As a result, the image source restrictions are not applied to the images that can be shown, which can
        also lead to a form of <a href="https://owasp.org/www-community/attacks/Content_Spoofing">Content Spoofing</a>.
        Similarly, the app's performance and behavior can be negatively affected by using too large or slow-to-load
        images.

        <aside class="info">
          The <code>$sanitize</code> service is also internally used by the <a
          href="https://docs.angularjs.org/api/ng/directive/ngBindHtml">ngBindHtml</a> directive and the <a
          href="https://docs.angularjs.org/api/ngSanitize/filter/linky">linky</a> filter, so any vulnerabilities affect
          them as well.
        </aside>
      </td>
    </tr>
  </table>
</section>

<section class="repro-instructions-section">
  <h2>Reproduction instructions</h2>
  <p>
    The app below demonstrates the issue by inserting a sanitized HTML string containing SVG images that should be
    blocked by the image source sanitization rules.
  </p>
  <p>
    The app uses the <a href="https://docs.angularjs.org/api/ngSanitize">ngSanitize</a> module to sanitize HTML.
  <pre>
      angular.module('app', ['ngSanitize']);
    </pre>
  </p>
  <p>
    For demonstration purposes, the app is configured to only allow images from the <code>https://angularjs.org/</code>
    domain:
  <pre>
      $compileProvider.imgSrcSanitizationTrustedUrlList(/^https:\/\/angularjs\.org\//);
    </pre>
  </p>
  <p>
    However, by taking advantage of the lack of sanitization for SVG <code>&lt;image></code> elements, we are able to
    show images from other domains (e.g. <code>https://angular.dev/</code>).
  </p>
  <p>
    <b>Steps:</b>
  <ol>
    <li>
      Choose an image URL type.
      <ul>
        <li><b>URL from allowed domain</b> is a URL that is allowed by the image source sanitization rules and should be
          kept in the sanitized HTML.
        </li>
        <li><b>URL from disallowed domain</b> is a URL that is disallowed by the image source sanitization rules and
          should be stripped from the sanitized HTML.
        </li>
      </ul>
    </li>
    <br/>
    <li>
      Choose an HTML payload type.
      <ul>
        <li>Types marked with <b>[SAFE]</b> are subject to proper sanitization with respect to image URLs.</li>
        <li>Types marked with <b>[UNSAFE]</b> can bypass image URL sanitization.</li>
      </ul>
    </li>
    <br/>
    <li>
      In the <b>Computed HTML payload</b> section, you can see the resulting HTML payload that will be used inserted
      into the DOM using <a href="https://docs.angularjs.org/api/ng/directive/ngBindHtml">ngBindHtml</a>.<br/>
      Note that <code>ngBindHtml</code> sanitizes its value using the <a
      href="https://docs.angularjs.org/api/ngSanitize/service/$sanitize">$sanitize</a> service.
    </li>
    <br/>
    <li>
      Look at the <b>Sanitized HTML</b> and <b>Rendered HTML</b> sections to see how different HTML payloads behave with
      respect to image source sanitization.
      <ul>
        <li>
          Observe that choosing an HTML template with a regular <code>&lt;img></code> element is subject to proper
          sanitization, meaning that it can only show an images from the allowed domains.
        </li>
        <li>
          In contrast, SVG <code>&lt;image></code> elements can bypass sanitization and show images from disallowed
          domains.
        </li>
      </ul>
    </li>
  </ol>
  </p>
</section>

<section class="repro-content-section" ng-app="app">
  <h2>Reproduction</h2>
  <span class="version-stamp">AngularJS v{{ version }}</span>
  <fieldset>
    <legend>Input</legend>
    <p>
      <label>
        <span>Choose image URL type:</span>
        <select
          ng-model="imageUrl"
          ng-options="item as item.label for item in imageUrls"
          ng-change="updateHtmlPayload()">
        </select>
      </label>
    </p>
    <p>
      <label>
        <span>Choose HTML payload type:</span>
        <select
          ng-model="htmlTemplate"
          ng-options="item as item.label for item in htmlTemplates"
          ng-change="updateHtmlPayload()">
        </select>
      </label>
    </p>
    <hr/>
    <p>
      Computed HTML payload:
    <pre ng-bind="htmlPayload"></pre>
    </p>
  </fieldset>
  <br/>
  <fieldset>
    <legend>Output</legend>
    <p>
      Sanitized HTML:
    <pre ng-bind="renderedHtml.html()"></pre>
    </p>
    <hr/>
    <p>
      Rendered HTML:
    <pre id="renderedHtml" class="rendered-html" ng-ref="renderedHtml" ng-bind-html="htmlPayload"></pre>
    </p>
    <hr/>
    <p>
      Linky usage:
    <pre class="rendered-html" ng-bind-html="htmlPayload  | linky:'_blank'"></pre>
    </p>
  </fieldset>
</section>

<script>
  // Define and configure the app.
  angular
    .module('app', ['ngSanitize'])
    .config([
      '$compileProvider', '$sanitizeProvider',
      ($compileProvider, $sanitizeProvider) => {
        // Before v1.8.1, use `imgSrcSanitizationWhitelist()` instead.
        $compileProvider.imgSrcSanitizationWhitelist(
          // Only allow images from `angularjs.org`.
          /^https:\/\/angularjs\.org\//);

        $compileProvider.aHrefSanitizationWhitelist(
          /^https:\/\/angularjs\.org\//);

        $sanitizeProvider.enableSvg(true);
      },
    ]).run(['$rootScope', "$timeout", (r, $timeout) => {
    const urlPlaceholder = 'URL_PLACEHOLDER';
    r.renderedHtml = null;
    r.updateHtmlPayload = () => {
      r.htmlPayload =
        r.htmlTemplate.value.replaceAll(urlPlaceholder, r.imageUrl.value);

      $timeout(() => {
        r.renderedHtml = angular.element(document.getElementById("renderedHtml"));
      });
    };

    r.imageUrls = [
      {
        label: 'URL from allowed domain',
        value: 'https://angularjs.org/favicon.ico',
      },
      {
        label: 'URL from disallowed domain',
        value: 'https://angular.dev/favicon.ico',
      },
    ];

    r.htmlTemplates = [
      {
        label: '[SAFE] Regular image with `src`',
        value: `<img src="${urlPlaceholder}" />`,
      },
      {
        label: '[UNSAFE] SVG image with `href`',
        value: `<svg><image href="${urlPlaceholder}"></image></svg>`,
      },
      {
        label: '[UNSAFE] SVG image with `xlink:href`',
        value: `<svg><image xlink:href="${urlPlaceholder}"></image></svg>`,
      },
    ];

    r.version = angular.version;
    r.imageUrl = r.imageUrls[0];
    r.htmlTemplate = r.htmlTemplates[0];
    r.updateHtmlPayload();
  }]);
</script>
</body>
</html>
```
</details>