### PR TITLE
2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="2.1.2"></a>
+# 2.1.2
+
+## Bug Fixes
+-  Fix CVE-2026-11998
+   - Note: Regex based trusted resource config values for urls can still be vulnerable to ReDoS based attacks. Protection for that though must be provided by consumer, via ReDoS safe Regex which conform with AngularJS documented warnings.
+
+
 <a name="2.1.1"></a>
 # 2.1.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angularjs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "angularjs",
   "license": "MIT",
-  "version": "2.1.1",
-  "distTag": "2.1.1",
+  "version": "2.1.2",
+  "distTag": "2.1.2",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -63,7 +63,7 @@ function adjustMatcher(matcher) {
     // The only other type of matcher allowed is a Regexp.
     // Match entire URL / disallow partial matches.
     // Flags are reset (i.e. no global, ignoreCase or multiline)
-    return new RegExp('^' + matcher.source + '$');
+    return new RegExp('^(?:' + matcher.source + ')$');
   } else {
     throw $sceMinErr('imatcher',
         'Matchers may only be "self", string patterns or RegExp objects');

--- a/workspace-scripts/config/Version.js
+++ b/workspace-scripts/config/Version.js
@@ -1,1 +1,1 @@
-export const version = "2.1.1";
+export const version = "2.1.2";


### PR DESCRIPTION
Fix [CVE-2026-11998](https://github.com/advisories/GHSA-7x27-g8rg-x87w)

**Note:** Regex based trusted resource config values for urls can still be vulnerable to ReDoS based attacks. Protection for that though must be provided by the supplier (developer) - ReDoS safe Regex which conform with AngularJS documented warnings.

- https://security.snyk.io/vuln/SNYK-JS-ANGULAR-17458840
- https://github.com/advisories/GHSA-7x27-g8rg-x87w

Demo of vulnerability on official AngularJS: https://codepen.io/herodevs/pen/JobQdmz/5b3896f56fab66f20cd25e698cf3faa8

<details>
<summary>Test file which can be used to show it local build is no longer vulnerable:</summary>

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>CVE-2025-0716</title>
  <style>
    /* Styles */
    aside {
      border: 0.1rem solid lightgray;
      border-radius: 0.5rem;
      font-size: 0.95em;
      margin: 0.5rem;
      padding: 0.5rem;
    }
    aside.info {
      background-color: aliceblue;
    }
    aside.warn {
      background-color: lemonchiffon;
    }

    body {
      font-family: arial, sans-serif;
      font-size: 1rem;
    }

    code {
      background-color: rgba(0, 0, 0, 0.125);
      border: 1px dotted darkgray;
      border-radius: 3px;
      display: inline-block;
      font-size: 0.95em;
      padding-left: 0.25rem;
      padding-right: 0.25rem;
    }

    h1 {
      text-align: center;
    }
    h1 > small {
      display: inline-block;
      font-style: italic;
      padding-block-end: 0.5rem;
    }

    kbd {
      background-color: snowwhite;
      border: 1px solid darkgray;
      border-radius: 0.25rem;
      font-size: 0.95em;
      padding-left: 0.25rem;
      padding-right: 0.25rem;
    }

    pre {
      background-color: lightgray;
      border: 1px solid dimgray;
      border-radius: 0.25rem;
      font-size: 0.95em;
      overflow: auto;
      padding: 0.5rem;
      white-space: pre-line;
    }
    pre.multi-line {
      white-space: pre;
    }

    section {
      border-block-start: 2px solid gray;
      padding: 0 1rem 1rem;
    }

    .vulnerability-info-table {
      border-spacing: 0.5rem;
      margin-inline-end: 1rem;
    }
    .vulnerability-info-table th {
      text-align: start;
      vertical-align: top;
      white-space: nowrap;
    }

    .repro-content-section button {
      margin: 0.25rem;
    }

    .repro-content-section .repro-btn {
      position: relative;
    }
    .repro-content-section .repro-btn::after {
      animation: spinner 0.5s linear infinite;
      border-radius: 50%;
      border-right: 2px solid transparent;
      border-top: 2px solid darkorchid;
      content: '';
      display: none;
      height: 1rem;
      margin-top: -0.5rem;
      position: absolute;
      right: -2rem;
      top: 50%;
      width: 1rem;
    }
    .repro-content-section .repro-btn:active::after {
      display: initial;
    }
    .repro-content-section .repro-btn:active + .repro-duration {
      visibility: hidden;
    }

    .repro-content-section .repro-duration {
      border-inline-start: 2px solid gray;
      padding-inline-start: 0.33rem;
    }

    .repro-instructions-section li {
      margin-block-end: 0.5rem;
    }

    [role="tooltip"] {
      cursor: help;
    }

    /* Animation keyframes */
    @keyframes spinner {
      to {
        transform: rotate(360deg);
      }
    }
  </style>
  <script src="./dist/angular/angular.js"></script>
</head>
<body>
<h1>
  <small>Reproduction of AngularJS vulnerability:</small><br />
  XSS via SCE resource URL sanitization bypass
</h1>

<section class="vulnerability-info-section">
  <h2>Vulnerability information</h2>
  <table class="vulnerability-info-table">
    <tr>
      <th>CVE:</th>
      <td><a href="https://www.cve.org/CVERecord?id=CVE-2026-11998">CVE-2026-11998</a></td>
    </tr>
    <tr>
      <th>Type:</th>
      <td><a href="https://owasp.org/www-community/attacks/xss">Cross-Site Scripting (XSS)</a></td>
    </tr>
    <tr>
      <th>Affected versions:</th>
      <td>>=1.2.0-rc.3</td>
    </tr>
    <tr>
      <th>Fixed in version:</th>
      <td><a href="https://www.herodevs.com/support/nes-angularjs">AngularJS NES</a> v1.9.12, v1.5.29 and v1.4.17</td>
    </tr>
    <tr>
      <th>Description:</th>
      <td>
        AngularJS uses the <a href="https://docs.angularjs.org/api/ng/service/$sce#strict-contextual-escaping">Strict Contextual Escaping (SCE)</a> mode (via its <code><a href="https://docs.angularjs.org/api/ng/service/$sce">$sce</a></code> and <code><a href="https://docs.angularjs.org/api/ng/service/$sceDelegate">$sceDelegate</a></code> services) to only render trusted or safe values for certain security-sensitive contexts. One of these contexts is resource URLs, such as those used to load JavaScript scripts, <code>&lt;iframe&gt;</code> documents, etc.
        To designate certain URLs as safe resource URLs, one can specify a list of URL matchers using the <code><a href="https://docs.angularjs.org/api/ng/provider/$sceDelegateProvider#trustedResourceUrlList">trustedResourceUrlList()</a></code> method. Each matcher can be either a string (with some wildcards) or a regular expression, which is supposed to be <q>matched against the <b>entire</b> <i>normalized / absolute URL</i> of the resource being tested (even when the RegExp did not have the <code>^</code> and <code>$</code> codes)</q>, according to the documentation.
        However, due to a flaw in the logic that tries to apply the regular expression to the entire URL, certain regular expressions may be partially applied. As a result, unsafe resource URLs values will fail to be blocked, potentially leading to <a href="https://owasp.org/www-community/attacks/xss">Cross-Site Scripting (XSS)</a>.
      </td>
    </tr>
  </table>
</section>

<section class="repro-instructions-section">
  <h2>Reproduction instructions</h2>
  <p>
    The app below demonstrates the issue by letting the user choose a resource URL matcher and a resource URL and verifying whether the URL is trusted by SCE.
  </p>
  <p>
    The app uses the <a href="https://docs.angularjs.org/api/ng/provider/$sceDelegateProvider#trustedResourceUrlList">$sceDelegateProvider#trustedResourceUrlList()</a> method to define the matchers for trusted resource URLs and the <a href="https://docs.angularjs.org/api/ng/service/$sce#getTrustedResourceUrl">$sce#getTrustedResourceUrl()</a> method to test the URL.
  <pre class="multi-line">
angular.
  module('app', []).
  config($sceDelegateProvider => {
    $sceDelegateProvider.trustedResourceUrlList([resourceUrlMatcher]);
  }).
  run($sce => {
    $sce.getTrustedResourceUrl(resourceUrl);
  });
    </pre>
  </p>
  <p>
    Additionally, the user can choose to insert a <code>&lt;script&gt;</code> element whose <code>src</code> is bound to the specified resource URL to see the sanitization/bypass in action.
  <pre>
      &lt;script ng-src="{{ resourceUrl }}">&lt;script>
    </pre>
  </p>
  <p>
    When choosing the vulnerable regular expression matcher (<code>/https:\/\/better\.com\/.*|https:\/\/good\.com\/.*/</code>), SCE should only allow resource URLs from <code>https://better.com/</code> and <code>https://good.com/</code>, if the pattern was correctly applied to the entire URL. However, by taking advantage of the implementation flaw in SCE, we are able execute arbitrary code, either loading scripts from other domains (e.g. <code>https://evil.com/...</code>) or through <code>data:</code> URLs.
  </p>
  <p>
    <b>Steps:</b>
  <ol>
    <li>
      Choose a matcher for trusted resource URLs.<br />
      This tells SCE which resource URLs should be trusted and thus allowed to be executed.
    </li>
    <br />
    <li>
      Choose a resource URL.<br />
      There is a list of example resource URLs, including malicious ones that can bypass certain matchers.
    </li>
    <br />
    <li>
      Choose whether you want the chosen URL to be bound an actual <code>&lt;script&gt;</code> element's <code>src</code>.<br />
      <aside class="warn">
        <b>WARNING</b><br />
        This may execute code from another domain in your browser.<br />
        Only check if you understand the implications.
      </aside>
    </li>
    <br />
    <li>
      Click the <kbd>Test resource URL</kbd> button.
    </li>
    <br />
    <li>
      In the <b>Output</b> section, you can see whether the chosen resource URL is considered safe and trusted by SCE.<br />
    </li>
    <br />
    <li>
      Also, if you chose to bind the resource URL to a <code>&lt;script&gt;</code> element, you might get an alert dialog, if the URL was considered safe and allowed by SCE to be loaded.<br />
      (If you don't see an alert dialog, it means that SCE blocked the resource URL.)
    </li>
  </ol>
  </p>
</section>

<section class="repro-content-section" ng-app="app">
  <h2>Reproduction</h2>
  <span class="version-stamp">AngularJS v{{ version }}</span>
  <fieldset>
    <legend>Input</legend>
    <p>
      <label>
        <span>Choose trusted resource URL matcher:</span>
        <select
          ng-model="resourceUrlMatcher"
          ng-options="item.value as item.label for item in resourceUrlMatchers">
        </select>
      </label>
    </p>
    <p>
      <label>
        <span>Specify resource URL to test:</span>
        <select
          ng-model="resourceUrl"
          ng-options="item for item in resourceUrls">
        </select>
      </label>
    </p>
    <p>
      <label>
        <span>Bind URL to <code>&lt;script&gt;</code> element:</span>
        <input type="checkbox" ng-model="bindToScript" />
        <span role="tooltip" title="Bind the resource URL to a `<script>` element's `ng-src` to see in action the sanitization or bypass.">ⓘ</span>
      </label>
    </p>
    <p>
      <button ng-click="testResourceUrl()">Test resource URL</button>
    </p>
  </fieldset>
  <br />
  <fieldset>
    <legend>Output</legend>
    <p>
      Trusted: <b>{{ isTrusted | json | uppercase }}</b>
    </p>
    <div ng-if="bindToScript">
      Script binding HTML:
      <pre ng-non-bindable>
        &lt;script ng-src="{{ resourceUrl }}">&lt;/script>
      </pre>
      <script ng-src="{{ resourceUrl }}" onerror="alert(`Tried to load script '${this.src}'.`)"></script>
    </div>
  </fieldset>
</section>
<script>
  let sceDelegateProvider;

  // Define and configure the app.
  angular
    .module('app', [])
    .config(['$sceDelegateProvider', $sceDelegateProvider => {
      // Keep a reference of `$sceDelegateProvider` for updating `trustedResourceUrlList` at runtime.
      // This is done for demonstration purposes only.
      sceDelegateProvider = $sceDelegateProvider;
    },
    ]).
  run([
    '$location', '$rootScope', '$sce', '$timeout',
    ($location, r, $sce, $timeout) => {
      r.resourceUrlMatchers = [
        {
          label: 'Special string: self',
          value: 'self',
        },
        {
          label: 'String matcher: https://good.com/*.js',
          value: 'https://good.com/*.js',
        },
        {
          label: 'RegExp (safe): /https:\/\/good\.com\/.*/',
          value: /https:\/\/good\.com\/.*/,
        },
        {
          label: 'RegExp (unsafe): /https:\/\/better\.com\/.*|https:\/\/good\.com\/.*/',
          value: /https:\/\/better\.com\/.*|https:\/\/good\.com\/.*/,
        },
      ];

      r.resourceUrls = [
        `${$location.protocol()}://${$location.host()}:${$location.port()}/script.js`,
        'https://good.com/scripts.js',
        'https://better.com/scripts.js',
        'https://evil.com/scripts.js',
        'https://evil.com/scripts.js#https://good.com/',
        'data:text/javascript,alert("HAX")//https://good.com/',
      ];

      // r.version = angular.version.full;
      r.resourceUrlMatcher = r.resourceUrlMatchers[0].value;
      r.resourceUrl = r.resourceUrls[0];
      r.isTrusted = 'N/A';
      r.bindToScript = false;

      r.testResourceUrl = () => {
        sceDelegateProvider.resourceUrlWhitelist([r.resourceUrlMatcher]);
        try {
          $sce.getTrustedResourceUrl(r.resourceUrl);
          r.isTrusted = true;
        } catch {
          r.isTrusted = false;
        }

        if (r.bindToScript === true) {
          r.bindToScript = false;
          $timeout(() => r.bindToScript = true);
        }
      };
    },
  ]);

</script>
</body>
</html>
```
</summary>
</details>